### PR TITLE
Add dashes to SPDX identifier

### DIFF
--- a/Example_header_metadata.md
+++ b/Example_header_metadata.md
@@ -4,6 +4,6 @@ This file provides example code to be put in a file that may or may not reach th
 ```
 #
 #   Copyright (C) 2017 Pelagicore AB
-#   SPDX license identifier: MIT
+#   SPDX-License-Identifier: MIT
 #
 ```


### PR DESCRIPTION
It seems an identifier should be using dashes:
https://spdx.org/spdx-specification-21-web-version#h.twlc0ztnng3b
